### PR TITLE
fix code in maldet for --mkpubpaths option to be cross-platform

### DIFF
--- a/files/maldet
+++ b/files/maldet
@@ -72,11 +72,11 @@ else
 							scan_user_access_minuid=10
 						fi
 						if [ "$uid" -ge "$scan_user_access_minuid" ] && [ ! -d "$userbasedir/$user" ]; then
-							mkdir -p $userbasedir/$user/quar $userbasedir/$user/sess $userbasedir/$user/tmp >> /dev/null 2>&1
-							touch $userbasedir/$user/event_log >> /dev/null 2>&1
-							chown -R $user.$user $userbasedir/$user >> /dev/null 2>&1
-							chmod 750 $userbasedir/$user $userbasedir/$user/quar $userbasedir/$user/sess $userbasedir/$user/tmp >> /dev/null 2>&1
-							chmod 640 $userbasedir/$user/event_log >> /dev/null 2>&1
+							mkdir -p $userbasedir/$user/quar $userbasedir/$user/sess $userbasedir/$user/tmp
+							touch $userbasedir/$user/event_log
+							chown -R $user $userbasedir/$user
+							chmod 750 $userbasedir/$user $userbasedir/$user/quar $userbasedir/$user/sess $userbasedir/$user/tmp
+							chmod 640 $userbasedir/$user/event_log
 							eout "{glob} created public scanning paths for user $user"
 						fi
 						unset uid user


### PR DESCRIPTION
-New versions of 'chown' don't use . (dot) to separate user and group
-In 'chown', group names are not always the same as user names. So "chown -R $user.$user" is not good in those circumstances and breaks permissions of those directories while public_scan is enabled. Moreover, not good to hide stderr while $user:$user is not working.
-There's no need to hide stderr, as these messages are extremely helpful for debugging purposes, and for watching that everything is fine to end-users, with different platforms.
